### PR TITLE
Support the `light` utility for setting the screen brightness

### DIFF
--- a/autolux/autolux.py
+++ b/autolux/autolux.py
@@ -16,6 +16,9 @@ def set_brightness(new_level, time):
   if opts.XRANDR_OUTPUT:
     import xrandr
     xrandr.set_brightness(new_level, time)
+  elif opts.LIGHT_OUTPUT:
+    import light
+    light.set_brightness(new_level, time)
   else:
     import xbacklight
     xbacklight.set_brightness(new_level, time)
@@ -24,7 +27,9 @@ def get_brightness():
   if opts.XRANDR_OUTPUT:
     import xrandr
     return xrandr.get_brightness()
-
+  elif opts.LIGHT_OUTPUT:
+    import light
+    return light.get_brightness()
   else:
     import xbacklight
     return xbacklight.get_brightness()

--- a/autolux/light.py
+++ b/autolux/light.py
@@ -5,8 +5,8 @@ import opts
 from run_cmd import run_cmd
 
 def set_brightness(new_level, time):
-    run_cmd("light -apS {:f}".format(new_level))
+    run_cmd("light -S {:f}".format(new_level))
 
 def get_brightness():
-    out = run_cmd("light -apG")
+    out = run_cmd("light -G")
     return float(out.strip())

--- a/autolux/light.py
+++ b/autolux/light.py
@@ -1,0 +1,12 @@
+# A small compatibility layer for `light`
+# https://github.com/haikarainen/light
+
+import opts
+from run_cmd import run_cmd
+
+def set_brightness(new_level, time):
+    run_cmd("light -apS {:f}".format(new_level))
+
+def get_brightness():
+    out = run_cmd("light -apG")
+    return float(out.strip())

--- a/autolux/opts.py
+++ b/autolux/opts.py
@@ -46,6 +46,9 @@ XRANDR_OUTPUT = None
 ADJUSTMENT = None
 RESET = False
 
+# do we use `light` to adjust the brightness
+LIGHT_OUTPUT = None
+
 VERBOSE=False
 def load_options():
   global MIN_LEVEL, MAX_LEVEL, MAX_WHITE, MIN_WHITE, CROP_SCREEN
@@ -54,6 +57,7 @@ def load_options():
   global PLOT_LUMA, PLOT_BRIGHT
   global RUN_AS_DAEMON, XRANDR_OUTPUT
   global ADJUSTMENT, RESET
+  global LIGHT_OUTPUT
 
   from optparse import OptionParser
   parser = OptionParser()
@@ -91,6 +95,7 @@ def load_options():
 
   parser.add_option("--adjust", dest="adjustment", type="float", default=None)
   parser.add_option("--reset", dest="reset", action="store_true", default=None)
+  parser.add_option("--light", dest="light_output", type="str", default=None)
 
 
 
@@ -114,6 +119,7 @@ def load_options():
   XRANDR_OUTPUT=options.xrandr_output
   ADJUSTMENT=options.adjustment
   RESET=options.reset
+  LIGHT_OUTPUT=options.light_output
 
   MIN_WHITE = options.min_white
   MAX_WHITE = options.max_white

--- a/autolux/opts.py
+++ b/autolux/opts.py
@@ -91,11 +91,11 @@ def load_options():
   parser.add_option("--plot-luma", dest="plot_luma", action="store_true", help="plot screen luminence on y axis and predicted brightness as color, good for observing prefered brightness by time of day", default=PLOT_LUMA)
   parser.add_option("--plot-brightness", dest="plot_luma", action="store_false", help="plot predicted brightness on y axis and input luminence as color, good for observing eye strain", default=not PLOT_LUMA)
 
-  parser.add_option("--xrandr", dest="xrandr_output", type="str", default=None)
+  parser.add_option("--use-xrandr", dest="xrandr_output", action="store_true")
 
   parser.add_option("--adjust", dest="adjustment", type="float", default=None)
   parser.add_option("--reset", dest="reset", action="store_true", default=None)
-  parser.add_option("--light", dest="light_output", type="str", default=None)
+  parser.add_option("--use-light", dest="light_output", action="store_true")
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try: desc=open('README.rst').read()
 except: pass
 setup(
     name='autolux',
-    version='0.0.34',
+    version='0.0.35',
     author='okay',
     author_email='okay.zed+al@gmail.com',
     packages=['autolux' ],


### PR DESCRIPTION
This PR adds initial support for setting the brightness using `light` (https://github.com/haikarainen/light).

Support is still very basic, and relies on `light` using meaningful defaults. For instance, the controller is selected automatically by `light` and cannot be changed, and brightness is read/written directly as a percentage.

It is a bit laggy and still does not work on Wayland, but it does the trick on Xorg!

Let me know if you have comments or suggestions.